### PR TITLE
JENKINS-32983: Parsing Maven Invoker results from slave

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,30 +1,31 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
 <!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.424</version>
-    <!-- which version of Jenkins is this plugin built against? -->
+    <version>2.3</version>
+    <relativePath />
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -43,31 +44,85 @@ under the License.
     <tag>HEAD</tag>
   </scm>
 
+  <properties>
+    <mavenVersion>3.1.0</mavenVersion>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>maven-plugin</artifactId>
+        <version>2.12.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <version>2.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.4</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <version>1.9.2</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-lang</groupId>
+        <artifactId>commons-lang</artifactId>
+        <version>2.6</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kohsuke.stapler</groupId>
+        <artifactId>stapler</artifactId>
+        <version>1.237</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
-      <version>1.424</version>
-      <scope>compile</scope>
+    </dependency>
+    <!-- Undeclared dependencies transitively retrieved from maven-plugin because their tricky configuration and exclusions: -->
+    <!-- org.eclipse.sisu:org.eclipse.sisu.plexus which needs exclusions -->
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${mavenVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <version>${mavenVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <version>${mavenVersion}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-invoker-plugin</artifactId>
-      <version>1.6</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.2</version>
     </dependency>
     <dependency>
-      <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils</artifactId>
-      <version>1.8.3</version>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kohsuke.stapler</groupId>
+      <artifactId>stapler</artifactId>
     </dependency>
   </dependencies>
 
-  <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
@@ -82,51 +137,4 @@ under the License.
     </pluginRepository>
   </pluginRepositories>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.jenkins-ci.tools</groupId>
-          <artifactId>maven-hpi-plugin</artifactId>
-          <version>1.85</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.12</version>
-          <configuration>
-            <systemPropertyVariables>
-              <java.awt.headless>true</java.awt.headless>
-            </systemPropertyVariables>
-          </configuration>
-
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-release-plugin</artifactId>
-          <version>2.3.2</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
-
-  <profiles>
-    <profile>
-      <id>mvn-debug</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.jenkins-ci.tools</groupId>
-            <artifactId>maven-hpi-plugin</artifactId>
-            <version>1.85</version>
-            <configuration>
-              <systemProperties>
-                <hudson.maven.debugPort>5005</hudson.maven.debugPort>
-              </systemProperties>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,16 @@
         <version>2.12.1</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>4.5.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>4.4.4</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
         <version>2.0.0</version>

--- a/src/findbugs/excludesFilter.xml
+++ b/src/findbugs/excludesFilter.xml
@@ -1,0 +1,12 @@
+<FindBugsFilter>
+     <Match>
+       <Class name="org.jenkinsci.plugins.maveninvoker.MavenInvokerArchiver$2" />
+       <Method name="call" />
+       <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" />
+     </Match>
+     <Match>
+       <Class name="org.jenkinsci.plugins.maveninvoker.MavenInvokerBuildAction" />
+       <Method name="getMavenInvokerResults" />
+       <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" />
+     </Match>
+</FindBugsFilter>

--- a/src/main/java/org/jenkinsci/plugins/maveninvoker/InvokerMavenAggregatedReport.java
+++ b/src/main/java/org/jenkinsci/plugins/maveninvoker/InvokerMavenAggregatedReport.java
@@ -28,6 +28,7 @@ import hudson.maven.MavenModuleSet;
 import hudson.model.Action;
 import hudson.model.AbstractBuild;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -121,8 +122,10 @@ public class InvokerMavenAggregatedReport
     public static final MavenInvokerResultComparator COMPARATOR_INSTANCE = new MavenInvokerResultComparator();
 
     public static class MavenInvokerResultComparator
-        implements Comparator<MavenInvokerResult>
+        implements Comparator<MavenInvokerResult>, Serializable
     {
+        private static final long serialVersionUID = 1L;
+
         @Override
         public int compare( MavenInvokerResult mavenInvokerResult, MavenInvokerResult mavenInvokerResult1 )
         {

--- a/src/main/java/org/jenkinsci/plugins/maveninvoker/InvokerMavenAggregatedReport.java
+++ b/src/main/java/org/jenkinsci/plugins/maveninvoker/InvokerMavenAggregatedReport.java
@@ -1,4 +1,5 @@
 package org.jenkinsci.plugins.maveninvoker;
+
 /*
  * Copyright (c) Olivier Lamy
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -24,16 +25,15 @@ import hudson.maven.MavenAggregatedReport;
 import hudson.maven.MavenBuild;
 import hudson.maven.MavenModule;
 import hudson.maven.MavenModuleSet;
-import hudson.model.AbstractBuild;
 import hudson.model.Action;
-import org.jenkinsci.plugins.maveninvoker.results.MavenInvokerResult;
-import org.jenkinsci.plugins.maveninvoker.results.MavenInvokerResults;
+import hudson.model.AbstractBuild;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+
+import org.jenkinsci.plugins.maveninvoker.results.MavenInvokerResult;
+import org.jenkinsci.plugins.maveninvoker.results.MavenInvokerResults;
 
 /**
  * @author Olivier Lamy
@@ -55,18 +55,19 @@ public class InvokerMavenAggregatedReport
         super( build );
     }
 
+    @Override
     public void update( Map<MavenModule, List<MavenBuild>> moduleBuilds, MavenBuild newBuild )
     {
         InvokerReport invokerReport = newBuild.getAction( InvokerReport.class );
 
         if ( invokerReport != null )
         {
-            MavenInvokerResults mavenInvokerResults = invokerReport.getMavenInvokerResults();
-            if ( mavenInvokerResults != null )
+            MavenInvokerResults miResults = invokerReport.getMavenInvokerResults();
+            if ( miResults != null )
             {
-                List<MavenInvokerResult> results = mavenInvokerResults.mavenInvokerResults;
-                this.mavenInvokerResults.mavenInvokerResults.addAll( results );
-                initTestCountsFields( this.mavenInvokerResults );
+                List<MavenInvokerResult> results = miResults.mavenInvokerResults;
+                mavenInvokerResults.mavenInvokerResults.addAll( results );
+                initTestCountsFields( mavenInvokerResults );
             }
         }
     }
@@ -74,14 +75,16 @@ public class InvokerMavenAggregatedReport
     @Override
     public MavenInvokerResults getMavenInvokerResults()
     {
-        return this.mavenInvokerResults;
+        return mavenInvokerResults;
     }
 
+    @Override
     public Class<? extends AggregatableAction> getIndividualActionType()
     {
         return InvokerReport.class;
     }
 
+    @Override
     public Action getProjectAction( MavenModuleSet moduleSet )
     {
         return this;
@@ -90,6 +93,8 @@ public class InvokerMavenAggregatedReport
     public static class MavenInvokerAggregatedBuildAction
         extends MavenInvokerBuildAction
     {
+        private static final long serialVersionUID = 1L;
+
         MavenInvokerResults mavenInvokerResults;
 
         public MavenInvokerAggregatedBuildAction( AbstractBuild<?, ?> build, MavenInvokerResults mavenInvokerResults )
@@ -101,7 +106,7 @@ public class InvokerMavenAggregatedReport
         @Override
         public MavenInvokerResults getMavenInvokerResults()
         {
-            return this.mavenInvokerResults;
+            return mavenInvokerResults;
         }
 
         @Override
@@ -118,6 +123,7 @@ public class InvokerMavenAggregatedReport
     public static class MavenInvokerResultComparator
         implements Comparator<MavenInvokerResult>
     {
+        @Override
         public int compare( MavenInvokerResult mavenInvokerResult, MavenInvokerResult mavenInvokerResult1 )
         {
             if ( mavenInvokerResult.mavenModuleName == null )

--- a/src/main/java/org/jenkinsci/plugins/maveninvoker/InvokerReport.java
+++ b/src/main/java/org/jenkinsci/plugins/maveninvoker/InvokerReport.java
@@ -1,4 +1,5 @@
 package org.jenkinsci.plugins.maveninvoker;
+
 /*
  * Copyright (c) Olivier Lamy
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -38,6 +39,8 @@ public class InvokerReport
     implements AggregatableAction
 {
 
+    private static final long serialVersionUID = 1L;
+
     private MavenInvokerResults mavenInvokerResults;
 
     public InvokerReport( AbstractBuild<?, ?> build, MavenInvokerResults mavenInvokerResults )
@@ -46,30 +49,19 @@ public class InvokerReport
         this.mavenInvokerResults = mavenInvokerResults;
     }
 
+    @Override
     public MavenAggregatedReport createAggregatedAction( MavenModuleSetBuild build,
                                                          Map<MavenModule, List<MavenBuild>> moduleBuilds )
     {
 
-        /*for ( Map.Entry<MavenModule, List<MavenBuild>> entry : moduleBuilds.entrySet() )
-        {
-            for ( MavenBuild mavenBuild : entry.getValue() )
-            {
-
-                MavenInvokerBuildAction mavenInvokerBuildAction = mavenBuild.getAction( MavenInvokerBuildAction.class );
-                if ( mavenInvokerBuildAction != null )
-                {
-                    MavenInvokerResults mavenInvokerResults = mavenInvokerBuildAction.getMavenInvokerResults();
-                    if ( mavenInvokerResults != null )
-                    {
-                        List<MavenInvokerResult> results = mavenInvokerResults.mavenInvokerResults;
-                        if ( results != null )
-                        {
-                            this.mavenInvokerResults.mavenInvokerResults.addAll( results );
-                        }
-                    }
-                }
-            }
-        }*/
+        /*
+         * for ( Map.Entry<MavenModule, List<MavenBuild>> entry : moduleBuilds.entrySet() ) { for ( MavenBuild
+         * mavenBuild : entry.getValue() ) { MavenInvokerBuildAction mavenInvokerBuildAction = mavenBuild.getAction(
+         * MavenInvokerBuildAction.class ); if ( mavenInvokerBuildAction != null ) { MavenInvokerResults
+         * mavenInvokerResults = mavenInvokerBuildAction.getMavenInvokerResults(); if ( mavenInvokerResults != null ) {
+         * List<MavenInvokerResult> results = mavenInvokerResults.mavenInvokerResults; if ( results != null ) {
+         * this.mavenInvokerResults.mavenInvokerResults.addAll( results ); } } } } }
+         */
         InvokerMavenAggregatedReport invokerMavenAggregatedReport =
             build.getAction( InvokerMavenAggregatedReport.class );
         if ( invokerMavenAggregatedReport != null )
@@ -82,6 +74,6 @@ public class InvokerReport
     @Override
     public MavenInvokerResults getMavenInvokerResults()
     {
-        return this.mavenInvokerResults;
+        return mavenInvokerResults;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/maveninvoker/MavenInvokerArchiver.java
+++ b/src/main/java/org/jenkinsci/plugins/maveninvoker/MavenInvokerArchiver.java
@@ -112,9 +112,6 @@ public class MavenInvokerArchiver
                     BuildJob buildJob = reader.read( is );
                     MavenInvokerResult mavenInvokerResult = MavenInvokerRecorder.map( buildJob );
                     mavenInvokerResult.mavenModuleName = pom.getArtifactId();
-
-                    logger.println( "mavenInvokerResult:" + mavenInvokerResult );
-
                     mavenInvokerResults.mavenInvokerResults.add( mavenInvokerResult );
                 }
                 catch ( XmlPullParserException e )
@@ -128,6 +125,7 @@ public class MavenInvokerArchiver
                     IOUtils.closeQuietly( is );
                 }
             }
+            logger.println( "Finished parsing Maven Invoker results" );
 
             int failedCount = build.execute( new MavenBuildProxy.BuildCallable<Integer, IOException>()
             {

--- a/src/main/java/org/jenkinsci/plugins/maveninvoker/MavenInvokerArchiver.java
+++ b/src/main/java/org/jenkinsci/plugins/maveninvoker/MavenInvokerArchiver.java
@@ -61,8 +61,8 @@ public class MavenInvokerArchiver
                                 Throwable error )
         throws InterruptedException, IOException
     {
-        if ( !mojo.is( "org.apache.maven.plugins", "maven-invoker-plugin", "run" ) && !mojo.is(
-            "org.apache.maven.plugins", "maven-invoker-plugin", "integration-test" ) )
+        if ( !mojo.is( "org.apache.maven.plugins", "maven-invoker-plugin", "run" )
+            && !mojo.is( "org.apache.maven.plugins", "maven-invoker-plugin", "integration-test" ) )
         {
             return true;
         }
@@ -73,15 +73,16 @@ public class MavenInvokerArchiver
         File[] reports = new File[0];
         try
         {
-            //projectsDirectory
+            // projectsDirectory
             final File projectsDirectory = mojo.getConfigurationValue( "projectsDirectory", File.class );
 
-            //cloneProjectsTo
+            // cloneProjectsTo
             final File cloneProjectsTo = mojo.getConfigurationValue( "cloneProjectsTo", File.class );
 
             final File reportsDir = mojo.getConfigurationValue( "reportsDirectory", File.class );
             reports = reportsDir.listFiles( new FilenameFilter()
             {
+                @Override
                 public boolean accept( File file, String s )
                 {
                     return s.startsWith( "BUILD" );
@@ -132,16 +133,16 @@ public class MavenInvokerArchiver
             {
                 private static final long serialVersionUID = 1L;
 
-                public Integer call( MavenBuild build )
+                @Override
+                public Integer call( MavenBuild aBuild )
                     throws IOException, IOException, InterruptedException
                 {
 
-                    FilePath[] reportsPaths = MavenInvokerRecorder.locateReports( build.getWorkspace(),
-                                                                                  buildDirectory + "/"
-                                                                                      + reportsDir.getName()
-                                                                                      + "/BUILD*.xml" );
+                    FilePath[] reportsPaths =
+                        MavenInvokerRecorder.locateReports( aBuild.getWorkspace(),
+                                                            buildDirectory + "/" + reportsDir.getName() + "/BUILD*.xml" );
 
-                    FilePath backupDirectory = MavenInvokerRecorder.getMavenInvokerReportsDirectory( build );
+                    FilePath backupDirectory = MavenInvokerRecorder.getMavenInvokerReportsDirectory( aBuild );
 
                     MavenInvokerRecorder.saveReports( backupDirectory, reportsPaths );
 
@@ -156,8 +157,9 @@ public class MavenInvokerArchiver
 
                         File projectDir = new File( invokerBuildDir, mavenInvokerResult.project );
 
-                        FilePath[] buildLogs = MavenInvokerRecorder.locateBuildLogs( build.getWorkspace(), "**/"
-                            + projectDir.getParentFile().getName() );
+                        FilePath[] buildLogs =
+                            MavenInvokerRecorder.locateBuildLogs( aBuild.getWorkspace(), "**/"
+                                + projectDir.getParentFile().getName() );
 
                         if ( buildLogs != null )
                         {
@@ -168,15 +170,14 @@ public class MavenInvokerArchiver
                     // backup all build.log
                     MavenInvokerRecorder.saveBuildLogs( backupDirectory, allBuildLogs );
 
-                    InvokerReport invokerReport = new InvokerReport( build, mavenInvokerResults );
-                    build.getActions().add( invokerReport );
+                    InvokerReport invokerReport = new InvokerReport( aBuild, mavenInvokerResults );
+                    aBuild.addAction( invokerReport );
                     int failed = invokerReport.getFailedTestCount();
                     return failed;
                 }
             } );
 
             return true;
-
 
         }
         catch ( ComponentConfigurationException e )
@@ -187,7 +188,6 @@ public class MavenInvokerArchiver
         }
 
     }
-
 
     @Extension
     public static final class DescriptorImpl
@@ -200,7 +200,6 @@ public class MavenInvokerArchiver
             // FIXME i18n
             return "Maven Invoker Plugin Results";
         }
-
 
         @Override
         public MavenReporter newAutoInstance( MavenModule module )

--- a/src/main/java/org/jenkinsci/plugins/maveninvoker/MavenInvokerArchiver.java
+++ b/src/main/java/org/jenkinsci/plugins/maveninvoker/MavenInvokerArchiver.java
@@ -70,7 +70,7 @@ public class MavenInvokerArchiver
 
         final PrintStream logger = listener.getLogger();
         logger.println( "MavenInvokerArchiver" );
-        File[] reports = new File[0];
+        File[] reports = null;
         try
         {
             // projectsDirectory
@@ -80,14 +80,17 @@ public class MavenInvokerArchiver
             final File cloneProjectsTo = mojo.getConfigurationValue( "cloneProjectsTo", File.class );
 
             final File reportsDir = mojo.getConfigurationValue( "reportsDirectory", File.class );
-            reports = reportsDir.listFiles( new FilenameFilter()
+            if ( reportsDir != null )
             {
-                @Override
-                public boolean accept( File file, String s )
+                reports = reportsDir.listFiles( new FilenameFilter()
                 {
-                    return s.startsWith( "BUILD" );
-                }
-            } );
+                    @Override
+                    public boolean accept( File file, String s )
+                    {
+                        return s.startsWith( "BUILD" );
+                    }
+                } );
+            }
 
             if ( reports != null )
             {
@@ -135,7 +138,10 @@ public class MavenInvokerArchiver
                 public Integer call( MavenBuild aBuild )
                     throws IOException, IOException, InterruptedException
                 {
-
+                    if ( reportsDir == null )
+                    {
+                        return 0;
+                    }
                     FilePath[] reportsPaths =
                         MavenInvokerRecorder.locateReports( aBuild.getWorkspace(),
                                                             buildDirectory + "/" + reportsDir.getName() + "/BUILD*.xml" );
@@ -155,10 +161,14 @@ public class MavenInvokerArchiver
 
                         File projectDir = new File( invokerBuildDir, mavenInvokerResult.project );
 
-                        FilePath[] buildLogs =
-                            MavenInvokerRecorder.locateBuildLogs( aBuild.getWorkspace(), "**/"
-                                + projectDir.getParentFile().getName() );
-
+                        FilePath[] buildLogs = null;
+                        File parentFile = projectDir.getParentFile();
+                        if ( parentFile != null )
+                        {
+                            buildLogs =
+                                MavenInvokerRecorder.locateBuildLogs( aBuild.getWorkspace(),
+                                                                      "**/" + parentFile.getName() );
+                        }
                         if ( buildLogs != null )
                         {
                             allBuildLogs.addAll( Arrays.asList( buildLogs ) );

--- a/src/main/java/org/jenkinsci/plugins/maveninvoker/MavenInvokerBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/maveninvoker/MavenInvokerBuildAction.java
@@ -1,4 +1,5 @@
 package org.jenkinsci.plugins.maveninvoker;
+
 /*
  * Copyright (c) Olivier Lamy
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -79,7 +80,7 @@ public class MavenInvokerBuildAction
         if ( mavenInvokerResults == null || mavenInvokerResults.get() == null
             || mavenInvokerResults.get().mavenInvokerResults.isEmpty() )
         {
-            FilePath directory = MavenInvokerRecorder.getMavenInvokerReportsDirectory( this.build );
+            FilePath directory = MavenInvokerRecorder.getMavenInvokerReportsDirectory( build );
             FilePath[] paths = null;
             try
             {
@@ -92,28 +93,31 @@ public class MavenInvokerBuildAction
             }
             if ( paths == null )
             {
-                this.mavenInvokerResults = new WeakReference<MavenInvokerResults>( new MavenInvokerResults() );
+                mavenInvokerResults = new WeakReference<MavenInvokerResults>( new MavenInvokerResults() );
             }
             else
             {
-                this.mavenInvokerResults = new WeakReference<MavenInvokerResults>( loadResults( paths ) );
+                mavenInvokerResults = new WeakReference<MavenInvokerResults>( loadResults( paths ) );
             }
         }
         MavenInvokerResults results = mavenInvokerResults.get();
         return results;
     }
 
+    @Override
     public String getDisplayName()
     {
         // FIXME i18n
         return "Maven Invoker Plugin Results";
     }
 
+    @Override
     public String getUrlName()
     {
         return "maven-invoker-plugin-results";
     }
 
+    @Override
     public String getIconFileName()
     {
         return "/plugin/maven-invoker-plugin/icons/report.png";
@@ -174,9 +178,9 @@ public class MavenInvokerBuildAction
         return results;
     }
 
-    protected void initTestCountsFields( MavenInvokerResults mavenInvokerResults )
+    protected void initTestCountsFields( MavenInvokerResults miResults )
     {
-        for ( MavenInvokerResult result : mavenInvokerResults.mavenInvokerResults )
+        for ( MavenInvokerResult result : miResults.mavenInvokerResults )
         {
             String resultStr = result.result;
             if ( StringUtils.equals( resultStr, BuildJob.Result.ERROR ) )

--- a/src/main/java/org/jenkinsci/plugins/maveninvoker/MavenInvokerBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/maveninvoker/MavenInvokerBuildAction.java
@@ -51,9 +51,9 @@ public class MavenInvokerBuildAction
      */
     private static final long serialVersionUID = 31415927L;
 
-    private Reference<MavenInvokerResults> mavenInvokerResults;
+    private transient Reference<MavenInvokerResults> mavenInvokerResults;
 
-    private final AbstractBuild<?, ?> build;
+    private transient final AbstractBuild<?, ?> build;
 
     private transient int passedTestCount;
 

--- a/src/main/java/org/jenkinsci/plugins/maveninvoker/results/MavenInvokerResult.java
+++ b/src/main/java/org/jenkinsci/plugins/maveninvoker/results/MavenInvokerResult.java
@@ -27,9 +27,6 @@ import java.io.Serializable;
  */
 public class MavenInvokerResult implements Serializable {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 1L;
 
     // used with mavenReporter
@@ -70,4 +67,5 @@ public class MavenInvokerResult implements Serializable {
         sb.append('}');
         return sb.toString();
     }
+
 }

--- a/src/main/java/org/jenkinsci/plugins/maveninvoker/results/MavenInvokerResult.java
+++ b/src/main/java/org/jenkinsci/plugins/maveninvoker/results/MavenInvokerResult.java
@@ -1,4 +1,5 @@
 package org.jenkinsci.plugins.maveninvoker.results;
+
 /*
  * Copyright (c) Olivier Lamy
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -24,9 +25,12 @@ import java.io.Serializable;
 /**
  * @author Olivier Lamy
  */
-public class MavenInvokerResult
-    implements Serializable
-{
+public class MavenInvokerResult implements Serializable {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 1L;
 
     // used with mavenReporter
     public String mavenModuleName;
@@ -47,26 +51,23 @@ public class MavenInvokerResult
 
     public String buildLog;
 
-
-    public MavenInvokerResult()
-    {
+    public MavenInvokerResult() {
         // no op
     }
 
     @Override
-    public String toString()
-    {
+    public String toString() {
         final StringBuilder sb = new StringBuilder();
-        sb.append( "MavenInvokerResult" );
-        sb.append( "{project='" ).append( project ).append( '\'' );
-        sb.append( ", name='" ).append( name ).append( '\'' );
-        sb.append( ", description='" ).append( description ).append( '\'' );
-        sb.append( ", result='" ).append( result ).append( '\'' );
-        sb.append( ", failureMessage='" ).append( failureMessage ).append( '\'' );
-        sb.append( ", time=" ).append( time );
-        sb.append( ", type='" ).append( type ).append( '\'' );
-        sb.append( ", buildLog='" ).append( buildLog ).append( '\'' );
-        sb.append( '}' );
+        sb.append("MavenInvokerResult");
+        sb.append("{project='").append(project).append('\'');
+        sb.append(", name='").append(name).append('\'');
+        sb.append(", description='").append(description).append('\'');
+        sb.append(", result='").append(result).append('\'');
+        sb.append(", failureMessage='").append(failureMessage).append('\'');
+        sb.append(", time=").append(time);
+        sb.append(", type='").append(type).append('\'');
+        sb.append(", buildLog='").append(buildLog).append('\'');
+        sb.append('}');
         return sb.toString();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/maveninvoker/results/MavenInvokerResult.java
+++ b/src/main/java/org/jenkinsci/plugins/maveninvoker/results/MavenInvokerResult.java
@@ -25,7 +25,9 @@ import java.io.Serializable;
 /**
  * @author Olivier Lamy
  */
-public class MavenInvokerResult implements Serializable {
+public class MavenInvokerResult
+    implements Serializable
+{
 
     private static final long serialVersionUID = 1L;
 
@@ -44,27 +46,23 @@ public class MavenInvokerResult implements Serializable {
 
     public double time;
 
-    public String type;
-
-    public String buildLog;
-
-    public MavenInvokerResult() {
+    public MavenInvokerResult()
+    {
         // no op
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         final StringBuilder sb = new StringBuilder();
-        sb.append("MavenInvokerResult");
-        sb.append("{project='").append(project).append('\'');
-        sb.append(", name='").append(name).append('\'');
-        sb.append(", description='").append(description).append('\'');
-        sb.append(", result='").append(result).append('\'');
-        sb.append(", failureMessage='").append(failureMessage).append('\'');
-        sb.append(", time=").append(time);
-        sb.append(", type='").append(type).append('\'');
-        sb.append(", buildLog='").append(buildLog).append('\'');
-        sb.append('}');
+        sb.append( "MavenInvokerResult" );
+        sb.append( "{project='" ).append( project ).append( '\'' );
+        sb.append( ", name='" ).append( name ).append( '\'' );
+        sb.append( ", description='" ).append( description ).append( '\'' );
+        sb.append( ", result='" ).append( result ).append( '\'' );
+        sb.append( ", failureMessage='" ).append( failureMessage ).append( '\'' );
+        sb.append( ", time=" ).append( time );
+        sb.append( '}' );
         return sb.toString();
     }
 

--- a/src/main/java/org/jenkinsci/plugins/maveninvoker/results/MavenInvokerResults.java
+++ b/src/main/java/org/jenkinsci/plugins/maveninvoker/results/MavenInvokerResults.java
@@ -33,10 +33,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * @author Olivier Lamy
  */
 public class MavenInvokerResults implements Serializable {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 1L;
 
     public List<MavenInvokerResult> mavenInvokerResults = new CopyOnWriteArrayList<MavenInvokerResult>();

--- a/src/main/java/org/jenkinsci/plugins/maveninvoker/results/MavenInvokerResults.java
+++ b/src/main/java/org/jenkinsci/plugins/maveninvoker/results/MavenInvokerResults.java
@@ -1,4 +1,5 @@
 package org.jenkinsci.plugins.maveninvoker.results;
+
 /*
  * Copyright (c) Olivier Lamy
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -20,6 +21,7 @@ package org.jenkinsci.plugins.maveninvoker.results;
  */
 
 import org.jenkinsci.plugins.maveninvoker.InvokerMavenAggregatedReport;
+import org.jenkinsci.plugins.maveninvoker.results.MavenInvokerResult;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -30,21 +32,22 @@ import java.util.concurrent.CopyOnWriteArrayList;
 /**
  * @author Olivier Lamy
  */
-public class MavenInvokerResults
-    implements Serializable
-{
+public class MavenInvokerResults implements Serializable {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 1L;
 
     public List<MavenInvokerResult> mavenInvokerResults = new CopyOnWriteArrayList<MavenInvokerResult>();
 
-    public MavenInvokerResults()
-    {
+    public MavenInvokerResults() {
         // no op
     }
 
-    public List<MavenInvokerResult> getSortedMavenInvokerResults()
-    {
-        List<MavenInvokerResult> results = new ArrayList<MavenInvokerResult>( mavenInvokerResults );
-        Collections.sort( results, InvokerMavenAggregatedReport.COMPARATOR_INSTANCE );
+    public List<MavenInvokerResult> getSortedMavenInvokerResults() {
+        List<MavenInvokerResult> results = new ArrayList<MavenInvokerResult>(mavenInvokerResults);
+        Collections.sort(results, InvokerMavenAggregatedReport.COMPARATOR_INSTANCE);
         return results;
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/maveninvoker/InvokerMavenAggregatedReport/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/maveninvoker/InvokerMavenAggregatedReport/index.jelly
@@ -17,7 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/maveninvoker/MavenInvokerBuildAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/maveninvoker/MavenInvokerBuildAction/index.jelly
@@ -17,7 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 

--- a/src/main/resources/org/jenkinsci/plugins/maveninvoker/MavenInvokerBuildAction/summary.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/maveninvoker/MavenInvokerBuildAction/summary.jelly
@@ -17,6 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
    <t:summary icon="${it.iconFileName}">

--- a/src/main/resources/org/jenkinsci/plugins/maveninvoker/MavenInvokerRecorder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/maveninvoker/MavenInvokerRecorder/config.jelly
@@ -17,6 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:bh="/lib/health">
    <f:entry title="Maven Invoker report pattern">


### PR DESCRIPTION
First commit (bc8eec7) is only about upgrading to the latest versions and comes along with some formatting (sorry).
The second commit (2a9fc37) contains the fix to allow using that plugin with a build not executed on master.
See https://issues.jenkins-ci.org/browse/JENKINS-32983 for details.