### PR TITLE
JENKINS-65459: upgrade Apache maven-invoker-plugin to support new buildlog attribute in reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,17 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
-      <version>2.4.11</version>
+      <version>2.4.21</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.8.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.30</version>
     </dependency>
 
     <dependency>
@@ -102,7 +112,7 @@
     <dependency>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-invoker-plugin</artifactId>
-      <version>3.1.0</version>
+      <version>3.2.2</version>
       <exclusions>
         <exclusion>
           <groupId>org.sonatype.sisu</groupId>
@@ -118,17 +128,17 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.1.0</version>
+      <version>3.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.doxia</groupId>
       <artifactId>doxia-core</artifactId>
-      <version>1.7</version>
+      <version>1.9.1</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-interpolation</artifactId>
-      <version>1.24</version>
+      <version>1.26</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>
@@ -138,7 +148,7 @@
     <dependency>
       <groupId> org.codehaus.plexus</groupId>
       <artifactId>plexus-component-annotations</artifactId>
-      <version>1.7.1</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/src/test/resources/invoker-reports/BUILD-simple-jsp-fail.xml
+++ b/src/test/resources/invoker-reports/BUILD-simple-jsp-fail.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<build-job project="simple-jsp-fail/pom.xml" name="" description="" result="failure-build" time="7.536" type="normal" />
+<build-job project="simple-jsp-fail/pom.xml" name="" description="" result="failure-build" time="7.536" type="normal" buildlog="../it/simple-jsp-fail/build.log" />

--- a/src/test/resources/invoker-reports/BUILD-simple-jsp.xml
+++ b/src/test/resources/invoker-reports/BUILD-simple-jsp.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<build-job project="simple-jsp/pom.xml" name="" description="" result="success" time="6.791" type="normal" />
+<build-job project="simple-jsp/pom.xml" name="" description="" result="success" time="6.791" type="normal" buildlog="../it/simple-jsp/build.log" />


### PR DESCRIPTION
This PR upgrades the apache maven-invoker-plugin dependency, to add support to the new buildlog attribute in invoker reports, during parsing them.

See https://issues.apache.org/jira/browse/MINVOKER-250 and https://github.com/apache/maven-invoker-plugin/pull/20/files#diff-6cf7b8aa54c5276d4d1f17e1baded72bcb5f7f85f9d38c68efc3f1c2ed969fd9R107

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
