### PR TITLE
Update plugin parent POM and dependencies

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.2</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -24,46 +24,47 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.18</version>
+    <version>4.31</version>
     <relativePath />
   </parent>
 
   <artifactId>maven-invoker-plugin</artifactId>
-  <version>2.5-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
   <name>Jenkins Maven Invoker plugin</name>
   <description>Reports on Maven Invoker it tests</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Maven+Invoker+Plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}</url>
 
   <scm>
-    <connection>scm:git:https://github.com/jenkinsci/maven-invoker-plugin.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/jenkinsci/maven-invoker-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/maven-invoker-plugin</url>
-    <tag>HEAD</tag>
+    <connection>scm:git:https://github.com/${gitHubRepo}</connection>
+    <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
+    <tag>${scmTag}</tag>
   </scm>
 
   <properties>
-    <mavenVersion>3.2.3</mavenVersion>
-    <jenkins.version>2.222.4</jenkins.version>
+    <revision>2.5</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <mavenVersion>3.8.3</mavenVersion>
+    <jenkins.version>2.321</jenkins.version>
     <java.level>8</java.level>
-    <workflow-cps.version>2.37</workflow-cps.version>
-    <workflow-support.version>2.14</workflow-support.version>
+    <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.222.x</artifactId>
-        <version>15</version>
+        <artifactId>bom-2.319.x</artifactId>
+        <version>1013.vf8058992a042</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.30</version>
+        <version>1.7.32</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -72,22 +73,19 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>1.18</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.8.1</version>
-    </dependency>
-
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>${mavenVersion}</version>
       <exclusions>
         <exclusion>
-          <groupId>org.sonatype.sisu</groupId>
-          <artifactId>sisu-guice</artifactId>
+          <groupId>com.google.inject</groupId>
+          <artifactId>guice</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -100,6 +98,16 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-embedder</artifactId>
       <version>${mavenVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.inject</groupId>
+          <artifactId>guice</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.ant</groupId>
@@ -111,15 +119,14 @@
       <version>${mavenVersion}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-      <version>4.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-invoker-plugin</artifactId>
       <version>3.2.2</version>
       <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>groovy-all</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.sonatype.sisu</groupId>
           <artifactId>sisu-guice</artifactId>
@@ -127,65 +134,27 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-repository-metadata</artifactId>
-      <version>3.2.3</version>
-    </dependency>
-    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.3.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.doxia</groupId>
-      <artifactId>doxia-core</artifactId>
-      <version>1.9.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-interpolation</artifactId>
-      <version>1.26</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
-    </dependency>
-    <dependency>
-      <groupId> org.codehaus.plexus</groupId>
-      <artifactId>plexus-component-annotations</artifactId>
-      <version>2.0.0</version>
+      <version>3.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-aether-provider</artifactId>
-      <version>3.2.3</version>
+      <version>3.3.9</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-api</artifactId>
-      <version>2.6</version>
+      <version>3.4.3</version>
     </dependency>
-
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
     </dependency>
-<!--    <dependency>-->
-<!--      <groupId>org.jenkins-ci.plugins.workflow</groupId>-->
-<!--      <artifactId>workflow-step-api</artifactId>-->
-<!--      <version>2.12</version>-->
-<!--    </dependency>-->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
-<!--      <version>2.22</version>-->
-<!--      <exclusions>-->
-<!--        <exclusion>-->
-<!--          <groupId>org.jenkins-ci.plugins</groupId>-->
-<!--          <artifactId>scm-api</artifactId>-->
-<!--        </exclusion>-->
-<!--      </exclusions>-->
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -194,14 +163,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.8.5</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -216,38 +178,28 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>${workflow-cps.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-basic-steps</artifactId>
-      <version>2.6</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
-      <version>${workflow-support.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>pipeline-stage-step</artifactId>
-      <version>2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <version>2.13</version>
       <scope>test</scope>
     </dependency>
 
@@ -273,7 +225,6 @@
         <plugin>
           <groupId>org.jenkins-ci.tools</groupId>
           <artifactId>maven-hpi-plugin</artifactId>
-          <version>2.0</version>
           <configuration>
             <jenkinsHome>${project.basedir}/.work</jenkinsHome>
             <consoleForceReload>false</consoleForceReload>

--- a/src/main/java/org/jenkinsci/plugins/maveninvoker/MavenInvokerBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/maveninvoker/MavenInvokerBuildAction.java
@@ -20,6 +20,7 @@ package org.jenkinsci.plugins.maveninvoker;
  * under the License.
  */
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.FilePath;
 import hudson.model.Api;
 import hudson.model.Run;
@@ -240,6 +241,7 @@ public class MavenInvokerBuildAction
         }
     }
 
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE") // see https://github.com/spotbugs/spotbugs/issues/651
     public InvokerResult getResult( String url)
     {
         try

--- a/src/main/java/org/jenkinsci/plugins/maveninvoker/pipeline/MavenInvokerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/maveninvoker/pipeline/MavenInvokerStep.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.maveninvoker.pipeline;
 
-import com.google.common.collect.ImmutableSet;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -14,6 +13,8 @@ import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 public class MavenInvokerStep
@@ -86,7 +87,9 @@ public class MavenInvokerStep
         @Override
         public Set<? extends Class<?>> getRequiredContext()
         {
-            return ImmutableSet.of( FilePath.class, FlowNode.class, TaskListener.class, Launcher.class );
+            Set<Class<?>> context = new HashSet<>();
+            Collections.addAll(context, FilePath.class, FlowNode.class, TaskListener.class, Launcher.class);
+            return Collections.unmodifiableSet(context);
         }
 
     }


### PR DESCRIPTION
**Untested** PR to update the plugin parent POM and dependencies to recent versions. Notably, by depending on Jenkins core 2.321 we can stop bundling Guava and Guice.